### PR TITLE
Fix issue with exporting SMIL files introduced in Sigil 0.9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **ePub3-itizer** is a python 2.7 and python 3.4 output plugin for Sigil 
 that will convert a valid epub2 epub into a valid epub3 epub.
 
-Updated: December 14, 2015
+Updated: February 12, 2016
 
 **Very Important Note**
 Support for this plugin is only provided for Sigil 0.8.6 or later. 

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -310,6 +310,10 @@ def patch_smil(bk, mid, href):
 
     original_smil_data = bk.readfile(mid)
     try:
+        # remove the XML declaration, if present
+        # otherwise lxml.etree will choke on it
+        original_smil_data = original_smil_data.replace('<?xml version="1.0" encoding="utf-8" ?>', "").strip()
+
         # parse SMIL file
         # this is a very simplified parsing, as it simply extract <text> and <audio> elements
         # it should cover any reasonable SMIL file, though

--- a/src/plugin.xml
+++ b/src/plugin.xml
@@ -6,7 +6,7 @@
 <description>Create ePub 3 from valid ePub2 with extensions</description>
 <engine>python3.4</engine>
 <engine>python2.7</engine>
-<version>0.3.5</version>
+<version>0.3.6</version>
 <autostart>true</autostart>
 <oslist>osx,win,unx</oslist>
 </plugin>


### PR DESCRIPTION
Starting with v0.9.3, Sigil adds an XML declaration to SMIL files added by plugins calling `bk.addfile()`.

The XML declaration makes `lxml.etree` choke, so the patching of SMIL files by ePub3-itizer is not completed correctly.

This commit fixes the problem and it is compatible with both Sigil 0.9.3 and pre-0.9.3.

(Probably the long-term solution will be replacing `lxml` with `gumbo` ?)
